### PR TITLE
feat: allow thunked objects to be spreadable

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,11 +116,7 @@ class ThunkProxy {
     if (this.memo === undefined)
       this.memo = g();
 
-    return {
-      value: this.memo[k],
-      enumerable: true,
-      configurable: true
-    };
+    return Reflect.getOwnPropertyDescriptor(this.memo, k);
   }
 
   get(g, k) {

--- a/index.js
+++ b/index.js
@@ -104,6 +104,24 @@ class ThunkProxy {
     Object.defineProperty(this.memo, k, descriptor);
     return true;
   }
+  
+  ownKeys(g) {
+    if (this.memo === undefined)
+      this.memo = g();
+
+    return Reflect.ownKeys(this.memo);
+  }
+
+  getOwnPropertyDescriptor(g, k) {
+    if (this.memo === undefined)
+      this.memo = g();
+
+    return {
+      value: this.memo[k],
+      enumerable: true,
+      configurable: true
+    };
+  }
 
   get(g, k) {
     if (this.memo === undefined)


### PR DESCRIPTION
Arrays returned in thunks can concatenated with the spread operator while objects cannot. This adds traps for ownKeys and getOwnPropertyDescriptor on ThunkProxy to allow non-iterable objects to be spreadable.